### PR TITLE
Add pointwise multiplication for vectors

### DIFF
--- a/Sources/arm/shader/MaterialParser.hx
+++ b/Sources/arm/shader/MaterialParser.hx
@@ -974,6 +974,9 @@ class MaterialParser {
 			else if (op == "NORMALIZE") {
 				return 'normalize($vec1)';
 			}
+			else if (op == "MULTIPLY") {
+				return '($vec1 * $vec2)';
+			}
 		}
 		else if (node.type == "Displacement") {
 			var height = parse_value_input(node.inputs[0]);

--- a/Sources/arm/shader/NodesMaterial.hx
+++ b/Sources/arm/shader/NodesMaterial.hx
@@ -2462,7 +2462,7 @@ class NodesMaterial {
 					{
 						name: _tr("operation"),
 						type: "ENUM",
-						data: [_tr("Add"), _tr("Subtract"), _tr("Average"), _tr("Dot Product"), _tr("Cross Product"), _tr("Normalize")],
+						data: [_tr("Add"), _tr("Subtract"), _tr("Average"), _tr("Dot Product"), _tr("Cross Product"), _tr("Normalize"), _tr("Multiply")],
 						default_value: 0,
 						output: 0
 					}


### PR DESCRIPTION
I think it is handy to have the possibility to pointwise multiply vectors e.g. for flipping and other operations. The brush vector math node got the same function.