### PR TITLE
Added Divide, Reflect, Project, Length, Distance to vector math node, implemented clamp and map range node

### DIFF
--- a/Sources/arm/shader/MaterialParser.hx
+++ b/Sources/arm/shader/MaterialParser.hx
@@ -1470,6 +1470,39 @@ class MaterialParser {
 				return "0.0";
 			}
 		}
+		else if (node.type == "CLAMP") {
+			var val = parse_value_input(node.inputs[0]);
+			var min = parse_value_input(node.inputs[1]);
+			var max = parse_value_input(node.inputs[2]);
+			var but = node.buttons[0]; //operation; 
+			var op: String = but.data[but.default_value].toUpperCase();
+			op = op.replace(" ", "_");
+			
+			if (op == "MIN_MAX") {
+				return '(clamp($val, $min, $max))';
+			}
+			else if (op == "RANGE") {
+				return '(clamp($val, min($min,$max), max($min,$max)))';
+			}
+		}
+		else if (node.type == "MAPRANGE") {
+			var val = parse_value_input(node.inputs[0]);
+			var fmin = parse_value_input(node.inputs[1]);
+			var fmax = parse_value_input(node.inputs[2]);
+			var tmin = parse_value_input(node.inputs[3]);
+			var tmax = parse_value_input(node.inputs[4]);
+			
+			var use_clamp = node.buttons[0].default_value == true;
+			
+			var a = '(($tmin - $tmax)/($fmin-$fmax))';
+			var out_val = '($a*$val + $tmin - $a*$fmin)';
+			if (use_clamp) {
+				return '(clamp($out_val, $tmin, $tmax))';
+			}
+			else {
+				return out_val;
+			}
+		}
 		else if (customNodes.get(node.type) != null) {
 			return customNodes.get(node.type)(node, socket);
 		}

--- a/Sources/arm/shader/MaterialParser.hx
+++ b/Sources/arm/shader/MaterialParser.hx
@@ -968,6 +968,12 @@ class MaterialParser {
 			else if (op == "DOT_PRODUCT") {
 				return to_vec3('dot($vec1, $vec2)');
 			}
+			else if(op == "LENGTH") {
+				return to_vec3('length($vec1)');
+			}
+			else if(op == "DISTANCE") {
+				return to_vec3('distance($vec1,$vec2)');
+			}
 			else if (op == "CROSS_PRODUCT") {
 				return 'cross($vec1, $vec2)';
 			}
@@ -976,6 +982,15 @@ class MaterialParser {
 			}
 			else if (op == "MULTIPLY") {
 				return '($vec1 * $vec2)';
+			}
+			else if (op == "DIVIDE") {
+				return 'vec3(${vec1}.x / (${vec2}.x == 0 ? 0.000001 : ${vec2}.x),${vec1}.y / (${vec2}.y == 0 ? 0.000001 : ${vec2}.y),${vec1}.z / (${vec2}.z == 0 ? 0.000001 : ${vec2}.z))';
+			}
+			else if (op == "PROJECT") {
+				return '(dot($vec1,$vec2)/dot($vec2,$vec2)*$vec2)';
+			}
+			else if (op == "REFLECT") {
+				return 'reflect($vec1,normalize($vec2))';
 			}
 		}
 		else if (node.type == "Displacement") {
@@ -1465,6 +1480,12 @@ class MaterialParser {
 			op = op.replace(" ", "_");
 			if (op == "DOT_PRODUCT") {
 				return 'dot($vec1, $vec2)';
+			}
+			else if(op == "LENGTH") {
+				return 'length($vec1)';
+			}
+			else if(op == "DISTANCE") {
+				return 'distance($vec1,$vec2)';
 			}
 			else {
 				return "0.0";

--- a/Sources/arm/shader/NodesMaterial.hx
+++ b/Sources/arm/shader/NodesMaterial.hx
@@ -2462,7 +2462,7 @@ class NodesMaterial {
 					{
 						name: _tr("operation"),
 						type: "ENUM",
-						data: [_tr("Add"), _tr("Subtract"), _tr("Average"), _tr("Dot Product"), _tr("Cross Product"), _tr("Normalize"), _tr("Multiply")],
+						data: [_tr("Add"), _tr("Subtract"), _tr("Multiply"), _tr("Divide"), _tr("Average"), _tr("Dot Product"), _tr("Cross Product"), _tr("Normalize"), _tr("Project"), _tr("Reflect"),_tr("Length"), _tr("Distance")],
 						default_value: 0,
 						output: 0
 					}

--- a/Sources/arm/shader/NodesMaterial.hx
+++ b/Sources/arm/shader/NodesMaterial.hx
@@ -2467,6 +2467,127 @@ class NodesMaterial {
 						output: 0
 					}
 				]
+			},
+			{
+				id: 0,
+				name: _tr("Clamp"),
+				type: "CLAMP",
+				x: 0,
+				y: 0,
+				color: 0xff62676d,
+				inputs: [
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Value"),
+						type: "VALUE",
+						color: 0xffa1a1a1,
+						default_value: 0.5
+					},
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Min"),
+						type: "VALUE",
+						color: 0xffa1a1a1,
+						default_value: 0.0
+					},
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Max"),
+						type: "VALUE",
+						color: 0xffa1a1a1,
+						default_value: 1.0
+					}
+				],
+				outputs: [
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Value"),
+						type: "VALUE",
+						color: 0xffa1a1a1,
+						default_value: 0.0
+					}
+				],
+				buttons: [
+					{
+						name: _tr("operation"),
+						type: "ENUM",
+						data: [_tr("Min Max"), _tr("Range")],
+						default_value: 0,
+						output: 0
+					}
+				]
+			},
+			{
+				id: 0,
+				name: _tr("Map Range"),
+				type: "MAPRANGE",
+				x: 0,
+				y: 0,
+				color: 0xff62676d,
+				inputs: [
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Value"),
+						type: "VALUE",
+						color: 0xffa1a1a1,
+						default_value: 0.5
+					},
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("From Min"),
+						type: "VALUE",
+						color: 0xffa1a1a1,
+						default_value: 0.0
+					},
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("From Max"),
+						type: "VALUE",
+						color: 0xffa1a1a1,
+						default_value: 1.0
+					},
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("To Min"),
+						type: "VALUE",
+						color: 0xffa1a1a1,
+						default_value: 0.0
+					},
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("To Max"),
+						type: "VALUE",
+						color: 0xffa1a1a1,
+						default_value: 1.0
+					}
+				],
+				outputs: [
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Value"),
+						type: "VALUE",
+						color: 0xffa1a1a1,
+						default_value: 0.0
+					}
+				],
+				buttons: [
+					{
+						name: _tr("use_clamp"),
+						type: "BOOL",
+						default_value: false,
+						output: 0
+					}
+				]
 			}
 		],
 		[ // Input


### PR DESCRIPTION
I added some missing but useful operations to vector math node to improve compatibility with Blender.
Now ArmorPaint supports all operations that are not marked.
![ap1](https://user-images.githubusercontent.com/28649121/115699067-9878a580-a365-11eb-89a1-1ceda07da5ac.png)
Scale could also be useful but it does not fit the node's interface.  But there is already mapping node which is much more flexible or one could simply use pointwise multiplication.
Should I also implement the pointwise operations? I did not do that so far because I personally never used them and I do not really see the point in a pointwise sin/cos/... Also it might make ArmorPaint's UI clunky because the list would get so long.
