### PR TITLE
Improve nodes

### DIFF
--- a/Sources/arm/shader/MaterialParser.hx
+++ b/Sources/arm/shader/MaterialParser.hx
@@ -490,7 +490,8 @@ class MaterialParser {
 			var tex = make_texture(node, tex_name);
 			if (tex != null) {
 				var to_linear = node.buttons[1].default_value == 1; // srgb to linear
-				var texstore = texture_store(node, tex, tex_name, to_linear);
+				var invert_color = node.buttons[2].default_value == true;
+				var texstore = texture_store(node, tex, tex_name, to_linear, invert_color);
 				return '$texstore.rgb';
 			}
 			else {
@@ -1264,7 +1265,8 @@ class MaterialParser {
 			var tex = make_texture(node, tex_name);
 			if (tex != null) {
 				var to_linear = node.buttons[1].default_value == 1; // srgb to linear
-				var texstore = texture_store(node, tex, tex_name, to_linear);
+				var invert_color = node.buttons[2].default_value == true;
+				var texstore = texture_store(node, tex, tex_name, to_linear, invert_color);
 				return '$texstore.a';
 			}
 		}
@@ -1631,7 +1633,7 @@ class MaterialParser {
 		return node_name(node) + "_store";
 	}
 
-	static function texture_store(node: TNode, tex: TBindTexture, tex_name: String, to_linear = false): String {
+	static function texture_store(node: TNode, tex: TBindTexture, tex_name: String, to_linear = false, invert_color = false): String {
 		matcon.bind_textures.push(tex);
 		curshader.context.add_elem("tex", "short2norm");
 		curshader.add_uniform("sampler2D " + tex_name);
@@ -1676,6 +1678,10 @@ class MaterialParser {
 
 		if (to_linear) {
 			curshader.write('$tex_store.rgb = pow($tex_store.rgb, vec3(2.2, 2.2, 2.2));');
+		}
+		
+		if (invert_color) {
+			curshader.write('$tex_store.rgb = 1.0 - $tex_store.rgb;');
 		}
 		return tex_store;
 	}

--- a/Sources/arm/shader/MaterialParser.hx
+++ b/Sources/arm/shader/MaterialParser.hx
@@ -1399,6 +1399,9 @@ class MaterialParser {
 			else if (op == "MODULO") {
 				out_val = 'mod($val1, $val2)';
 			}
+			else if (op == "PING-PONG") {
+				out_val = '(($val2 != 0.0) ? abs(fract(($val1 - $val2) / ($val2 * 2.0)) * $val2 * 2.0 - $val2) : 0.0)';
+			}
 			else if (op == "SINE") {
 				out_val = 'sin($val1)';
 			}

--- a/Sources/arm/shader/MaterialParser.hx
+++ b/Sources/arm/shader/MaterialParser.hx
@@ -935,8 +935,14 @@ class MaterialParser {
 		}
 		else if (node.type == "NORMAL_MAP") {
 			var strength = parse_value_input(node.inputs[0]);
-			parse_normal_map_color_input(node.inputs[1], strength);
-			return null;
+			var norm = parse_vector_input(node.inputs[1]);
+			
+			var store = store_var_name(node);
+			curshader.write('vec3 ${store}_texn = $norm * 2.0 - 1.0;');
+			curshader.write('${store}_texn.xy = $strength * ${store}_texn.xy;');
+			curshader.write('${store}_texn = normalize(${store}_texn);');
+			
+			return '(0.5*${store}_texn + 0.5)';
 		}
 		else if (node.type == "VECT_TRANSFORM") {
 		// 	#type = node.vector_type

--- a/Sources/arm/shader/NodesMaterial.hx
+++ b/Sources/arm/shader/NodesMaterial.hx
@@ -1980,6 +1980,43 @@ class NodesMaterial {
 			},
 			{
 				id: 0,
+				name: _tr("Normal Map"),
+				type: "NORMAL_MAP",
+				x: 0,
+				y: 0,
+				color: 0xff522c99,
+				inputs: [
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Stength"),
+						type: "VALUE",
+						color: 0xffa1a1a1,
+						default_value: 1.0
+					},
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Normal"),
+						type: "VECTOR",
+						color: -10238109,
+						default_value: f32([0.5, 0.5, 0.5])
+					}
+				],
+				outputs: [
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Normal"),
+						type: "VECTOR",
+						color: -10238109,
+						default_value: f32([0.5, 0.5, 0.5])
+					}
+				],
+				buttons: []
+			},
+			{
+				id: 0,
 				name: _tr("Vector Curves"),
 				type: "CURVE_VEC",
 				x: 0,

--- a/Sources/arm/shader/NodesMaterial.hx
+++ b/Sources/arm/shader/NodesMaterial.hx
@@ -1250,6 +1250,12 @@ class NodesMaterial {
 						type: "ENUM",
 						default_value: 0,
 						data: [_tr("linear"), _tr("srgb")]
+					},
+					{
+						name: _tr("Invert color"),
+						type: "BOOL",
+						default_value: false,
+						output: 0
 					}
 				]
 			},

--- a/Sources/arm/shader/NodesMaterial.hx
+++ b/Sources/arm/shader/NodesMaterial.hx
@@ -2282,7 +2282,7 @@ class NodesMaterial {
 					{
 						name: _tr("operation"),
 						type: "ENUM",
-						data: [_tr("Add"), _tr("Subtract"), _tr("Multiply"), _tr("Divide"), _tr("Power"), _tr("Logarithm"), _tr("Square Root"), _tr("Absolute"), _tr("Minimum"), _tr("Maximum"), _tr("Less Than"), _tr("Greater Than"), _tr("Round"), _tr("Floor"), _tr("Ceil"), _tr("Fract"), _tr("Modulo"), _tr("Sine"), _tr("Cosine"), _tr("Tangent"), _tr("Arcsine"), _tr("Arccosine"), _tr("Arctangent"), _tr("Arctan2")],
+						data: [_tr("Add"), _tr("Subtract"), _tr("Multiply"), _tr("Divide"), _tr("Power"), _tr("Logarithm"), _tr("Square Root"), _tr("Absolute"), _tr("Minimum"), _tr("Maximum"), _tr("Less Than"), _tr("Greater Than"), _tr("Round"), _tr("Floor"), _tr("Ceil"), _tr("Fract"), _tr("Modulo"), _tr("Ping-Pong"), _tr("Sine"), _tr("Cosine"), _tr("Tangent"), _tr("Arcsine"), _tr("Arccosine"), _tr("Arctangent"), _tr("Arctan2")],
 						default_value: 0,
 						output: 0
 					},


### PR DESCRIPTION
I implemented a few features for nodes.

1. @AlexKiryanov had the idea to implement the ping-pong operation (it's a saw-tooh function) for the math node. I also implemented it for the brush math node and will open a pull request when I'm at home again.
2. Normal map node: It works a bit like Blender's node but is compatible with ArmorPaint and has fewer features. To be precise it takes a normal map texture, changes the strength and returns a normal map texture again. This differs from Blender as Blender takes a normal map texture and produces a normal map.
3. Invert color option for the image node. It gives the user the option to invert colors (after converting to a color space). I think this is useful for masks as well as for importing smoothness textures. 