### PR TITLE
Fix multibyte characters in material name

### DIFF
--- a/Sources/arm/format/ObjParser.hx
+++ b/Sources/arm/format/ObjParser.hx
@@ -481,14 +481,14 @@ class ObjParser {
 	}
 
 	function readString(): String {
-		var s = "";
+		var begin = pos;
 		while (true) {
 			var c = bytes.get(pos);
 			if (c == "\n".code || c == "\r".code || c == " ".code) break;
 			pos++;
-			s += String.fromCharCode(c);
 		}
-		return s;
+		
+		return bytes.getString(begin,pos-begin);
 	}
 
 	function nextLine() {


### PR DESCRIPTION
ArmorPaint's ObjParser has support for extracting material names. Currently the extraction is done by reading byte by byte and converting each one to string. In case of multi-byte characters like €,Ä,Ö,Ü,ß and so on this does not work and produces garbage. For example consider this mesh
[cube.zip](https://github.com/armory3d/armorbase/files/6426016/cube.zip)

Solution: Read the whole name first and then convert it in one pass to avoid half utf8-codepoints.
