### PR TITLE
Add invert option to Normal Map node

### DIFF
--- a/Sources/arm/shader/MaterialParser.hx
+++ b/Sources/arm/shader/MaterialParser.hx
@@ -941,9 +941,13 @@ class MaterialParser {
 		else if (node.type == "NORMAL_MAP") {
 			var strength = parse_value_input(node.inputs[0]);
 			var norm = parse_vector_input(node.inputs[1]);
+			var invert_map = node.buttons[0].default_value == true;
 
 			var store = store_var_name(node);
 			curshader.write('vec3 ${store}_texn = $norm * 2.0 - 1.0;');
+			if (invert_map) {
+				curshader.write('${store}_texn.xy = -1.0 * ${store}_texn.xy;');
+			}
 			curshader.write('${store}_texn.xy = $strength * ${store}_texn.xy;');
 			curshader.write('${store}_texn = normalize(${store}_texn);');
 

--- a/Sources/arm/shader/NodesMaterial.hx
+++ b/Sources/arm/shader/NodesMaterial.hx
@@ -2016,7 +2016,14 @@ class NodesMaterial {
 						default_value: f32([0.5, 0.5, 1.0])
 					}
 				],
-				buttons: []
+				buttons: [
+					{
+						name: _tr("Invert"),
+						type: "BOOL",
+						default_value: false,
+						output: 0
+					}
+				]
 			},
 			{
 				id: 0,


### PR DESCRIPTION
I think it is a very handy option to invert normal maps in order to convert bumps to holes and vice versa.
