### PR TITLE
Add Blend Normal Maps node

### DIFF
--- a/Sources/arm/shader/MaterialParser.hx
+++ b/Sources/arm/shader/MaterialParser.hx
@@ -949,6 +949,35 @@ class MaterialParser {
 
 			return '(0.5 * ${store}_texn + 0.5)';
 		}
+		else if (node.type == "BLEND_NORMAL_MAPS") {
+			var nm1 = parse_vector_input(node.inputs[0]);
+			var nm2 = parse_vector_input(node.inputs[1]);
+			var but = node.buttons[0];
+			var blend: String = but.data[but.default_value].toUpperCase(); //blend type
+			blend = blend.replace(" ", "_");
+			
+			var store = store_var_name(node);
+			
+			/* The blending algorithms are based on the paper 'Blending in Detail' by Colin Barré-Brisebois and Stephen Hill 2012
+			   https://blog.selfshadow.com/publications/blending-in-detail/
+			*/
+			
+			if( blend == "PARTIAL_DERIVATIVE") { //partial derivate blending
+				curshader.write('vec3 ${store}_n1 = $nm1 * 2.0 - 1.0;');
+				curshader.write('vec3 ${store}_n2 = $nm2 * 2.0 - 1.0;');
+				return '0.5*normalize(vec3(${store}_n1.xy*${store}_n2.z + ${store}_n2.xy*${store}_n1.z, ${store}_n1.z*${store}_n2.z))+0.5;';
+			}
+			else if (blend == "WHITEOUT") { //whiteout blending
+				curshader.write('vec3 ${store}_n1 = $nm1 * 2.0 - 1.0;');
+				curshader.write('vec3 ${store}_n2 = $nm2 * 2.0 - 1.0;');
+				return '0.5*normalize(vec3(${store}_n1.xy + ${store}_n2.xy, ${store}_n1.z*${store}_n2.z))+0.5;';
+			}
+			else if (blend == "REORIENTED") { //reoriented normal mapping
+				curshader.write('vec3 ${store}_n1 = $nm1 * 2.0 - vec3(1.0,1.0,0.0);');
+				curshader.write('vec3 ${store}_n2 = $nm2 * vec3(-2.0,-2.0,2.0) - vec3(-1.0,-1.0,1.0);');
+				return '0.5*normalize(${store}_n1*dot(${store}_n1, ${store}_n2) - ${store}_n2*${store}_n1.z)+0.5';
+			}
+		}
 		else if (node.type == "VECT_TRANSFORM") {
 		// 	#type = node.vector_type
 		// 	#conv_from = node.convert_from

--- a/Sources/arm/shader/NodesMaterial.hx
+++ b/Sources/arm/shader/NodesMaterial.hx
@@ -2020,6 +2020,51 @@ class NodesMaterial {
 			},
 			{
 				id: 0,
+				name: _tr("Blend Normal Maps"),
+				type: "BLEND_NORMAL_MAPS",
+				x: 0,
+				y: 0,
+				color: 0xff522c99,
+				inputs: [
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("1. Normal Map"),
+						type: "VECTOR",
+						color: -10238109,
+						default_value: f32([0.5, 0.5, 1.0])
+					},
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("2. Normal Map"),
+						type: "VECTOR",
+						color: -10238109,
+						default_value: f32([0.5, 0.5, 1.0])
+					}
+				],
+				outputs: [
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Normal Map"),
+						type: "VECTOR",
+						color: -10238109,
+						default_value: f32([0.5, 0.5, 1.0])
+					}
+				],
+				buttons: [
+					{
+						name: _tr("blend_type"),
+						type: "ENUM",
+						data: [_tr("Partial Derivative"), _tr("Whiteout"), _tr("Reoriented")],
+						default_value: 0,
+						output: 0
+					}
+				]
+			},
+			{
+				id: 0,
 				name: _tr("Vector Curves"),
 				type: "CURVE_VEC",
 				x: 0,


### PR DESCRIPTION
To improve the normal map workflow I implemented a Blend Normal Maps node. It does exactly what its same says. 
As there is no canonical algorithm to blend two maps I added a small collection to give the user some choice. The algorithms are taken from [blog.selfshadow.com/publications/blending-in-detail](https://blog.selfshadow.com/publications/blending-in-detail/ ) and adapted to ArmorPaint's needs. I deliberately skipped the 'stupid' algorithms like linear blending or overlay as these flatten the normal maps and do treat the channels separately. Therefore I only implemented 'proper' ones to guide the user to better results. But if you wish to add those feel free to contact me.
Clearly the node has some similarity to MixRGB but does not support a Fac socket. The reason is that Blend Normal Maps does not compute some "weighted" average but tries to preserve the strength of both normal maps. It is kind of an union operation. If the user wishes to add some weights it is way better to construct something like this 

![ap1](https://user-images.githubusercontent.com/28649121/117439500-3312e000-af33-11eb-8fe7-742439cb6b33.jpg)

Imho the results are super cool and very easy to understand this way. 
