### PR TITLE
Add Quantize node

### DIFF
--- a/Sources/arm/shader/MaterialParser.hx
+++ b/Sources/arm/shader/MaterialParser.hx
@@ -676,6 +676,11 @@ class MaterialParser {
 			if (use_clamp) return 'clamp($out_col, vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0))';
 			else return out_col;
 		}
+		else if (node.type == "QUANTIZE") {
+			var amount = parse_value_input(node.inputs[0]);
+			var col = parse_vector_input(node.inputs[1]);
+			return '(floor($amount*$col)/$amount)';
+		}
 		else if (node.type == "VALTORGB") { // ColorRamp
 			var fac = parse_value_input(node.inputs[0]);
 			var interp = node.buttons[0].data == 0 ? "LINEAR" : "CONSTANT";

--- a/Sources/arm/shader/MaterialParser.hx
+++ b/Sources/arm/shader/MaterialParser.hx
@@ -679,7 +679,7 @@ class MaterialParser {
 		else if (node.type == "QUANTIZE") {
 			var amount = parse_value_input(node.inputs[0]);
 			var col = parse_vector_input(node.inputs[1]);
-			return '(floor($amount*$col)/$amount)';
+			return '(floor(100*$amount*$col)/(100*$amount))';
 		}
 		else if (node.type == "VALTORGB") { // ColorRamp
 			var fac = parse_value_input(node.inputs[0]);

--- a/Sources/arm/shader/NodesMaterial.hx
+++ b/Sources/arm/shader/NodesMaterial.hx
@@ -1837,9 +1837,9 @@ class NodesMaterial {
 						name: _tr("Amount"),
 						type: "VALUE",
 						color: 0xffa1a1a1,
-						default_value: 4.0,
-						min: 1.0,
-						max: 100
+						default_value: 0.1,
+						min: 0,
+						max: 1
 					},
 					{
 						id: 0,

--- a/Sources/arm/shader/NodesMaterial.hx
+++ b/Sources/arm/shader/NodesMaterial.hx
@@ -1822,6 +1822,45 @@ class NodesMaterial {
 						output: 0
 					}
 				]
+			},
+			{
+				id: 0,
+				name: _tr("Quantize"),
+				type: "QUANTIZE",
+				x: 0,
+				y: 0,
+				color: 0xff448c6d,
+				inputs: [
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Amount"),
+						type: "VALUE",
+						color: 0xffa1a1a1,
+						default_value: 4.0,
+						min: 1.0,
+						max: 100
+					},
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Color"),
+						type: "RGBA",
+						color: 0xffc7c729,
+						default_value: f32([0.0, 0.0, 0.0, 1.0])
+					}
+				],
+				outputs: [
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Color"),
+						type: "RGBA",
+						color: 0xffc7c729,
+						default_value: f32([0.8, 0.8, 0.8, 1.0])
+					}
+				],
+				buttons: []
 			}
 		],
 		[ // Vector


### PR DESCRIPTION
The following node is not really complicated but I think it adds an enormous amount of creative potential to ArmorPaint. The node allows for quantizing values (especially colors). The quantization amount is adjustable so you can create position dependent quantization effects like: Kindergarten reloaded
![ap1](https://user-images.githubusercontent.com/28649121/117445885-943eb180-af3b-11eb-8d9b-7b9643fc9656.jpg)

Even cooler you can easily create pixelated materials and paint pixelated. (I guess this is not the nodes's most obvious application) 
![ap2](https://user-images.githubusercontent.com/28649121/117445899-9acd2900-af3b-11eb-80ef-dac7ad4823b4.jpg)

@AlexKiryanov I guess this node would be a nice toy for you and under the assumption @luboslenco accepts the pull request I think painting pixelated materials is worth a video? -minecraft, retro art style, ...?