### PR TITLE
Added math operations in math and vector math node

### DIFF
--- a/Sources/arm/shader/MaterialParser.hx
+++ b/Sources/arm/shader/MaterialParser.hx
@@ -1034,6 +1034,42 @@ class MaterialParser {
 			else if (op == "REFLECT") {
 				return 'reflect($vec1, normalize($vec2))';
 			}
+			else if (op == "SCALE") {
+				return '(${vec2}.x * $vec1)';
+			}
+			else if (op == "ABSOLUTE") {
+				return 'abs($vec1)';
+			}
+			else if (op == "MINIMUM") {
+				return 'min($vec1, $vec2)';
+			}
+			else if (op == "MAXIMUM") {
+				return 'max($vec1, $vec2)';
+			}
+			else if (op == "FLOOR") {
+				return 'floor($vec1)';
+			}
+			else if (op == "CEIL") {
+				return 'ceil($vec1)';
+			}
+			else if (op == "FRACTION") {
+				return 'fract($vec1)';
+			}
+			else if (op == "MODULO") {
+				return 'mod($vec1, $vec2)';
+			}
+			else if(op == "SNAP") {
+				return '(floor($vec1 / $vec2) * $vec2)';
+			}
+			else if (op == "SINE") {
+				return 'sin($vec1)';
+			}
+			else if (op == "COSINE") {
+				return 'cos($vec1)';
+			}
+			else if (op == "TANGENT") {
+				return 'tan($vec1)';
+			}
 		}
 		else if (node.type == "Displacement") {
 			var height = parse_value_input(node.inputs[0]);
@@ -1403,6 +1439,12 @@ class MaterialParser {
 			else if (op == "SQUARE_ROOT") {
 				out_val = 'sqrt($val1)';
 			}
+			else if(op == "INVERSE_SQUARE_ROOT") {
+				out_val = 'inversesqrt($val1)';
+			}
+			else if (op == "EXPONENT") {
+				out_val = 'exp($val1)';
+			}
 			else if (op == "ABSOLUTE") {
 				out_val = 'abs($val1)';
 			}
@@ -1418,6 +1460,9 @@ class MaterialParser {
 			else if (op == "GREATER_THAN") {
 				out_val = 'float($val1 > $val2)';
 			}
+			else if (op == "SIGN") {
+				out_val = 'sign($val1)';
+			}
 			else if (op == "ROUND") {
 				out_val = 'floor($val1 + 0.5)';
 			}
@@ -1427,7 +1472,13 @@ class MaterialParser {
 			else if (op == "CEIL") {
 				out_val = 'ceil($val1)';
 			}
-			else if (op == "FRACT") {
+			else if(op == "SNAP") {
+				out_val = '(floor($val1 / $val2) * $val2)';
+			}
+			else if (op == "TRUNCATE") {
+				out_val = 'trunc($val1)';
+			}
+			else if (op == "FRACTION") {
 				out_val = 'fract($val1)';
 			}
 			else if (op == "MODULO") {
@@ -1456,6 +1507,21 @@ class MaterialParser {
 			}
 			else if (op == "ARCTAN2") {
 				out_val = 'atan2($val1, $val2)';
+			}
+			else if (op == "HYPERBOLIC_SINE") {
+				out_val = 'sinh($val1)';
+			}
+			else if (op == "HYPERBOLIC_COSINE") {
+				out_val = 'cosh($val1)';
+			}
+			else if (op == "HYPERBOLIC_TANGENT") {
+				out_val = 'tanh($val1)';
+			}
+			else if (op == "TO_RADIANS") {
+				out_val = 'radians($val1)';
+			}
+			else if (op == "TO_DEGREES") {
+				out_val = 'degrees($val1)';
 			}
 			if (use_clamp) {
 				return 'clamp($out_val, 0.0, 1.0)';

--- a/Sources/arm/shader/NodesMaterial.hx
+++ b/Sources/arm/shader/NodesMaterial.hx
@@ -2484,7 +2484,7 @@ class NodesMaterial {
 					{
 						name: _tr("operation"),
 						type: "ENUM",
-						data: [_tr("Add"), _tr("Subtract"), _tr("Multiply"), _tr("Divide"), _tr("Power"), _tr("Logarithm"), _tr("Square Root"), _tr("Absolute"), _tr("Minimum"), _tr("Maximum"), _tr("Less Than"), _tr("Greater Than"), _tr("Round"), _tr("Floor"), _tr("Ceil"), _tr("Fract"), _tr("Modulo"), _tr("Ping-Pong"), _tr("Sine"), _tr("Cosine"), _tr("Tangent"), _tr("Arcsine"), _tr("Arccosine"), _tr("Arctangent"), _tr("Arctan2")],
+						data: [_tr("Add"), _tr("Subtract"), _tr("Multiply"), _tr("Divide"), _tr("Power"), _tr("Logarithm"), _tr("Square Root"), _tr("Inverse Square Root"), _tr("Absolute"), _tr("Exponent"), _tr("Minimum"), _tr("Maximum"), _tr("Less Than"), _tr("Greater Than"), _tr("Sign"), _tr("Round"), _tr("Floor"), _tr("Ceil"), _tr("Truncate"), _tr("Fraction"), _tr("Modulo"), _tr("Snap"), _tr("Ping-Pong"), _tr("Sine"), _tr("Cosine"), _tr("Tangent"), _tr("Arcsine"), _tr("Arccosine"), _tr("Arctangent"), _tr("Arctan2"), _tr("Hyperbolic Sine"), _tr("Hyperbolic Cosine"), _tr("Hyperbolic Tangent"), _tr("To Radians"), _tr("To Degrees")],
 						default_value: 0,
 						output: 0
 					},
@@ -2707,7 +2707,7 @@ class NodesMaterial {
 					{
 						name: _tr("operation"),
 						type: "ENUM",
-						data: [_tr("Add"), _tr("Subtract"), _tr("Multiply"), _tr("Divide"), _tr("Average"), _tr("Dot Product"), _tr("Cross Product"), _tr("Normalize"), _tr("Project"), _tr("Reflect"), _tr("Length"), _tr("Distance")],
+						data: [_tr("Add"), _tr("Subtract"), _tr("Multiply"), _tr("Divide"), _tr("Average"), _tr("Cross Product"), _tr("Project"), _tr("Reflect"), _tr("Dot Product"), _tr("Distance"), _tr("Length"), _tr("Scale"), _tr("Normalize"), _tr("Absolute"), _tr("Minimum"), _tr("Maximum"), _tr("Floor"), _tr("Ceil"), _tr("Fraction"), _tr("Modulo"), _tr("Snap"), _tr("Sine"), _tr("Cosine"), _tr("Tangent")],
 						default_value: 0,
 						output: 0
 					}


### PR DESCRIPTION
I added the missing operations to math node and vector math node that have one or two operands. The list is now complete except for the operations having three operands. I also ordered them in the same way as Blender does to maximize compatibility. 
Please take a look at my implementation of the Scale operation in  the vector math node. Blender uses the second operand as scalar operand. Because ArmorPaint does not allow for switching the type of a socket I took the first component (x component) of the vector. If you plug in a scalar or vector value the behavior matches Blender behavior but the socket color is the wrong one. I thought this is the most consistent way to do it.

Finally the only remaining operations are the three operand ones. I did not dare to add a third socket because I was unsure whether this is a good idea or not. Please decide whether I should add a third one and implement the missing operations or not.