### PR TITLE
Move _tr to Translator

### DIFF
--- a/Sources/arm/Translator.hx
+++ b/Sources/arm/Translator.hx
@@ -19,6 +19,12 @@ class Translator {
 
 	static var lastLocale = "en";
 
+	// Mark strings as localizable in order to be parsed by the extract_locale script.
+	// The string will not be translated to the currently selected locale though.
+	public static inline function _tr(s: String) {
+		return s;
+	}
+
 	// Localizes a string with the given placeholders replaced (format is `{placeholderName}`).
 	// If the string isn't available in the translation, this method will return the source English string.
 	public static function tr(id: String, vars: Map<String, String> = null): String {

--- a/Sources/arm/shader/NodesMaterial.hx
+++ b/Sources/arm/shader/NodesMaterial.hx
@@ -5,13 +5,9 @@ import zui.Zui;
 import zui.Id;
 import zui.Nodes;
 import arm.Project;
+import arm.Translator._tr;
 
 class NodesMaterial {
-
-	// Mark strings as localizable
-	public static inline function _tr(s: String) {
-		return s;
-	}
 
 	public static var categories = [_tr("Input"), _tr("Texture"), _tr("Color"), _tr("Vector"), _tr("Converter"), _tr("Group")];
 


### PR DESCRIPTION
Code duplication is always bad and I guess this situation will reoccur in the future. Therefore it is good to have one defined way of solving it.