### PR TITLE
Center window if config is missing

### DIFF
--- a/Sources/arm/Config.hx
+++ b/Sources/arm/Config.hx
@@ -74,16 +74,25 @@ class Config {
 			raw.window_resizable = true;
 			raw.window_minimizable = true;
 			raw.window_maximizable = true;
+			var disp = Display.primary;
+			#if (krom_darwin || krom_windows || krom_linux)
+			raw.window_w = Std.int(Math.min(1600,Std.int(0.9*disp.width)));
+			raw.window_h = Std.int(Math.min(900, Std.int(0.8*disp.height)));
+			raw.window_x = Std.int(0.05*disp.width);
+			raw.window_y = Std.int(0.1*disp.height);
+			#else
 			raw.window_w = 1600;
 			raw.window_h = 900;
+			raw.window_x = -1;
+			raw.window_y = -1;
+			#end
 			#if krom_darwin
 			raw.window_w *= 2;
 			raw.window_h *= 2;
 			#end
-			raw.window_x = -1;
-			raw.window_y = -1;
+			
 			raw.window_scale = 1.0;
-			var disp = Display.primary;
+			
 			if (disp.width >= 2560 && disp.height >= 1600) {
 				raw.window_scale = 2.0;
 			}


### PR DESCRIPTION
https://github.com/armory3d/armorpaint/issues/1068 reported an issue where ArmorPaint's window was too big for the available display screen size.
This PR request tries to improve this situation by centering the window if the config is missing, e.g. on the first run. I added a margin on each side in order to prevent ArmorPaint from being placed under a taskbar (which could be on each side of the screen) or other window manager elements.
Unfortunately I could not try the behavior on MacOS. In particular I do not understand the
```
raw.window_w *= 2;
raw.window_h *= 2;
```
So you might want to adjust the code a bit. You might also want to tweak the numbers a bit but. The chosen one seem to work well on most displays and I suspect that a typical user will choose his/her window size afterwards and won't see this size and position the next time.