### PR TITLE
Add color mask node

### DIFF
--- a/Sources/arm/shader/MaterialParser.hx
+++ b/Sources/arm/shader/MaterialParser.hx
@@ -1414,6 +1414,14 @@ class MaterialParser {
 			var norout = vec3(node.outputs[0].default_value);
 			return 'dot($norout, $nor)';
 		}
+		else if (node.type == "COLMASK") {
+			var inputColor = parse_vector_input(node.inputs[0]);
+			var maskColor = parse_vector_input(node.inputs[1]);
+			var radius = parse_value_input(node.inputs[2]);
+			var fuzziness = parse_value_input(node.inputs[3]);
+
+			return 'clamp(1- (distance($inputColor,$maskColor) - $radius) / max($fuzziness,$eps),0.0,1.0)';
+		}
 		else if (node.type == "MATH") {
 			var val1 = parse_value_input(node.inputs[0]);
 			var val2 = parse_value_input(node.inputs[1]);

--- a/Sources/arm/shader/NodesMaterial.hx
+++ b/Sources/arm/shader/NodesMaterial.hx
@@ -2240,6 +2240,61 @@ class NodesMaterial {
 			},
 			{
 				id: 0,
+				name: _tr("Color Mask"),
+				type: "COLMASK",
+				x: 0,
+				y: 0,
+				color: 0xff62676d,
+				inputs: [
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Color"),
+						type: "RGBA",
+						color: 0xffc7c729,
+						default_value: f32([0.8, 0.8, 0.8, 1.0])
+					},
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Mask Color"),
+						type: "RGBA",
+						color: 0xffc7c729,
+						default_value: f32([0.8, 0.8, 0.8, 1.0])
+					},
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Radius"),
+						type: "VALUE",
+						color: 0xffa1a1a1,
+						default_value: 0.1,
+						min: 0.0,
+						max: 1.74
+					},
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Fuzziness"),
+						type: "VALUE",
+						color: 0xffa1a1a1,
+						default_value: 0.0
+					}
+				],
+				outputs: [
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Mask"),
+						type: "VALUE",
+						color: 0xffa1a1a1,
+						default_value: 0.0
+					}
+				],
+				buttons: []
+			},
+			{
+				id: 0,
 				name: _tr("Combine HSV"),
 				type: "COMBHSV",
 				x: 0,


### PR DESCRIPTION
The color mask node is basically a threshold node but on steroids with support for color textures. It allows the user to choose a color and a radius. Every color within this radius will be mapped to one, all others to zero. In order to allow for non binary masks to get softer "edges"  there is a fuzziness parameter. The node is useful to mask several features in a texture, to replace several parts by others (as fac-input to MixRGB node) or to create ambient-occlusion-like textures.
Example where the dark tones of wood are extracted.
![grafik](https://user-images.githubusercontent.com/28649121/154849291-a549551b-ef1f-43d7-80c6-c44b76607410.png)

![grafik](https://user-images.githubusercontent.com/28649121/154849523-847a32fa-11af-46c2-902e-493c58c2a619.png)

